### PR TITLE
✅ test: AI API Mock 서버 구축 및 부하 테스트 환경 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,25 @@ dependencies {
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+	useJUnitPlatform {
+		excludeTags 'load-test'
+	}
+}
+
+tasks.register('loadTest', Test) {
+	group = 'verification'
+	description = 'Run load/performance tests'
+
+	testClassesDirs = sourceSets.test.output.classesDirs
+	classpath = sourceSets.test.runtimeClasspath
+
+	useJUnitPlatform {
+		includeTags 'load-test'
+	}
+
+	testLogging {
+		showStandardStreams = true
+	}
 }
 
 tasks.named('check') {

--- a/src/main/java/com/vatti/chzscout/backend/ai/config/OpenAiConfig.java
+++ b/src/main/java/com/vatti/chzscout/backend/ai/config/OpenAiConfig.java
@@ -24,6 +24,9 @@ public class OpenAiConfig {
    */
   @Bean
   public OpenAIClient openAIClient() {
-    return OpenAIOkHttpClient.builder().apiKey(properties.getKey()).build();
+    return OpenAIOkHttpClient.builder()
+        .apiKey(properties.getKey())
+        .baseUrl(properties.getBaseUrl())
+        .build();
   }
 }

--- a/src/test/java/com/vatti/chzscout/backend/ai/performance/AiChatServiceLoadTest.java
+++ b/src/test/java/com/vatti/chzscout/backend/ai/performance/AiChatServiceLoadTest.java
@@ -1,0 +1,208 @@
+package com.vatti.chzscout.backend.ai.performance;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.vatti.chzscout.backend.ai.application.AiChatService;
+import com.vatti.chzscout.backend.ai.domain.dto.UserMessageAnalysisResult;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.LongSummaryStatistics;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * AI Chat Service 부하 테스트.
+ *
+ * <p>WireMock을 사용하여 OpenAI API 응답을 시뮬레이션하고, 동시 요청 시 성능을 측정합니다.
+ */
+@Tag("load-test")
+@SpringBootTest(properties = "openai.api.base-url=http://localhost:19999")
+@ActiveProfiles("test")
+class AiChatServiceLoadTest {
+
+  private static final int WIREMOCK_PORT = 19999;
+
+  @RegisterExtension
+  static WireMockExtension wireMock =
+      WireMockExtension.newInstance().options(wireMockConfig().port(WIREMOCK_PORT)).build();
+
+  @Autowired private AiChatService aiChatService;
+
+  // ==================== Burst 테스트 설정 ====================
+
+  /** API 응답 지연 시간 (ms) - Burst 테스트용 */
+  private static final int BURST_DELAY_MS = 2000;
+
+  /** 동시 요청 수 - Burst 테스트용 */
+  private static final int BURST_REQUESTS = 100;
+
+  // ==================== Sustained Load 테스트 설정 ====================
+
+  /** API 응답 지연 시간 (ms) */
+  private static final int SUSTAINED_DELAY_MS = 2000;
+
+  /** 초당 요청 수 (OkHttp 기본 maxRequestsPerHost=5 기준) */
+  private static final int REQUESTS_PER_SECOND = 5;
+
+  /** 테스트 지속 시간 (초) */
+  private static final int TEST_DURATION_SECONDS = 10;
+
+  /** 최대 동시 요청 수 = 초당 요청 × 지연 시간(초) = 10 */
+  private static final int MAX_CONCURRENT = REQUESTS_PER_SECOND * (SUSTAINED_DELAY_MS / 1000);
+
+  @BeforeEach
+  void setUp() {
+    stubOpenAiChatCompletion();
+  }
+
+  @Test
+  @DisplayName("동기 방식 Burst: 100개 요청 동시 발생")
+  void measureBurstPerformance() {
+    // given
+    stubWithDelay(BURST_DELAY_MS);
+    ExecutorService executor = Executors.newFixedThreadPool(BURST_REQUESTS);
+    List<CompletableFuture<Long>> futures = new ArrayList<>();
+
+    // when
+    long startTime = System.currentTimeMillis();
+
+    for (int i = 0; i < BURST_REQUESTS; i++) {
+      final int requestId = i;
+      futures.add(CompletableFuture.supplyAsync(() -> measureSingleRequest(requestId), executor));
+    }
+
+    List<Long> responseTimes = futures.stream().map(CompletableFuture::join).toList();
+    long totalTime = System.currentTimeMillis() - startTime;
+    executor.shutdown();
+
+    // then
+    printBurstReport(responseTimes, totalTime);
+    assertThat(responseTimes).hasSize(BURST_REQUESTS);
+  }
+
+  @Test
+  @DisplayName("동기 방식 Sustained: 초당 5회 × 10초 지속 부하")
+  void measureSustainedPerformance() throws InterruptedException {
+    // given
+    stubWithDelay(SUSTAINED_DELAY_MS);
+    ExecutorService executor = Executors.newFixedThreadPool(MAX_CONCURRENT);
+    List<CompletableFuture<Long>> futures = new ArrayList<>();
+    int totalRequests = REQUESTS_PER_SECOND * TEST_DURATION_SECONDS;
+
+    // when
+    long startTime = System.currentTimeMillis();
+
+    for (int second = 0; second < TEST_DURATION_SECONDS; second++) {
+      long secondStart = System.currentTimeMillis();
+
+      // 해당 초에 REQUESTS_PER_SECOND개 요청 발생
+      for (int i = 0; i < REQUESTS_PER_SECOND; i++) {
+        final int requestId = second * REQUESTS_PER_SECOND + i;
+        futures.add(CompletableFuture.supplyAsync(() -> measureSingleRequest(requestId), executor));
+      }
+
+      // 다음 초까지 대기 (정확한 초당 요청 수 유지)
+      long elapsed = System.currentTimeMillis() - secondStart;
+      if (elapsed < 1000) {
+        TimeUnit.MILLISECONDS.sleep(1000 - elapsed);
+      }
+    }
+
+    List<Long> responseTimes = futures.stream().map(CompletableFuture::join).toList();
+    long totalTime = System.currentTimeMillis() - startTime;
+    executor.shutdown();
+
+    // then
+    printSustainedReport(responseTimes, totalTime, totalRequests);
+    assertThat(responseTimes).hasSize(totalRequests);
+  }
+
+  // ==================== 헬퍼 메서드 ====================
+
+  /** 단일 요청 수행 및 응답 시간 측정 */
+  private long measureSingleRequest(int requestId) {
+    long requestStart = System.currentTimeMillis();
+    UserMessageAnalysisResult result = aiChatService.analyzeUserMessage("롤 방송 추천해줘 #" + requestId);
+    long requestEnd = System.currentTimeMillis();
+
+    assertThat(result).isNotNull();
+    assertThat(result.getIntent()).isEqualTo("recommendation");
+
+    return requestEnd - requestStart;
+  }
+
+  /** OpenAI Chat Completion API stub 설정 (기본 지연) */
+  private void stubOpenAiChatCompletion() {
+    stubWithDelay(BURST_DELAY_MS);
+  }
+
+  /** OpenAI Chat Completion API stub 설정 (지연 시간 지정) */
+  private void stubWithDelay(int delayMs) {
+    wireMock.resetAll();
+    String mockResponse = OpenAiResponseFixture.recommendationResponse();
+
+    wireMock.stubFor(
+        post(urlPathEqualTo("/chat/completions"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                    .withFixedDelay(delayMs)
+                    .withBody(mockResponse)));
+  }
+
+  // ==================== 리포트 출력 ====================
+
+  /** Burst 테스트 결과 출력 */
+  private void printBurstReport(List<Long> responseTimes, long totalTime) {
+    LongSummaryStatistics stats =
+        responseTimes.stream().mapToLong(Long::longValue).summaryStatistics();
+
+    System.out.println();
+    System.out.println("========== Burst 테스트 결과 ==========");
+    System.out.println("동시 요청 수: " + BURST_REQUESTS);
+    System.out.println("API 지연 시간: " + BURST_DELAY_MS + "ms");
+    System.out.println("총 소요 시간: " + totalTime + "ms");
+    System.out.printf("평균 응답 시간: %.2fms%n", stats.getAverage());
+    System.out.println("최소 응답 시간: " + stats.getMin() + "ms");
+    System.out.println("최대 응답 시간: " + stats.getMax() + "ms");
+    System.out.printf("처리량 (TPS): %.2f%n", BURST_REQUESTS * 1000.0 / totalTime);
+    System.out.println("=".repeat(45));
+    System.out.println();
+  }
+
+  /** Sustained Load 테스트 결과 출력 */
+  private void printSustainedReport(List<Long> responseTimes, long totalTime, int totalRequests) {
+    LongSummaryStatistics stats =
+        responseTimes.stream().mapToLong(Long::longValue).summaryStatistics();
+
+    System.out.println();
+    System.out.println("========== Sustained Load 테스트 결과 ==========");
+    System.out.println("초당 요청 수: " + REQUESTS_PER_SECOND);
+    System.out.println("테스트 지속 시간: " + TEST_DURATION_SECONDS + "초");
+    System.out.println("총 요청 수: " + totalRequests);
+    System.out.println("최대 동시 요청: " + MAX_CONCURRENT);
+    System.out.println("API 지연 시간: " + SUSTAINED_DELAY_MS + "ms");
+    System.out.println("총 소요 시간: " + totalTime + "ms");
+    System.out.printf("평균 응답 시간: %.2fms%n", stats.getAverage());
+    System.out.println("최소 응답 시간: " + stats.getMin() + "ms");
+    System.out.println("최대 응답 시간: " + stats.getMax() + "ms");
+    System.out.printf("처리량 (TPS): %.2f%n", totalRequests * 1000.0 / totalTime);
+    System.out.println("=".repeat(50));
+    System.out.println();
+  }
+}

--- a/src/test/java/com/vatti/chzscout/backend/ai/performance/OpenAiResponseFixture.java
+++ b/src/test/java/com/vatti/chzscout/backend/ai/performance/OpenAiResponseFixture.java
@@ -1,0 +1,94 @@
+package com.vatti.chzscout.backend.ai.performance;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vatti.chzscout.backend.ai.domain.dto.UserMessageAnalysisResult;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** OpenAI API 응답 Fixture. */
+public class OpenAiResponseFixture {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  // ==================== 공개 API ====================
+
+  /** 추천 요청에 대한 기본 응답을 생성합니다. */
+  public static String recommendationResponse() {
+    UserMessageAnalysisResult result =
+        new UserMessageAnalysisResult(
+            "recommendation", List.of("게임", "롤", "e스포츠"), List.of("롤", "게임"), null);
+    return chatCompletionResponse(result);
+  }
+
+  /** 검색 요청에 대한 기본 응답을 생성합니다. */
+  public static String searchResponse() {
+    UserMessageAnalysisResult result =
+        new UserMessageAnalysisResult("search", List.of(), List.of("페이커"), "페이커 방송을 검색합니다.");
+    return chatCompletionResponse(result);
+  }
+
+  /** Chat Completion API 응답을 생성합니다. */
+  public static String chatCompletionResponse(UserMessageAnalysisResult result) {
+    String contentJson = buildContentJson(result);
+    Map<String, Object> response = buildChatCompletion(contentJson);
+    return toJson(response);
+  }
+
+  // ==================== 응답 구조 빌더 ====================
+
+  /** 전체 Chat Completion 응답 구조를 빌드합니다. */
+  private static Map<String, Object> buildChatCompletion(String contentJson) {
+    Map<String, Object> response = new HashMap<>();
+    response.put("id", "chatcmpl-test-" + System.currentTimeMillis());
+    response.put("object", "chat.completion");
+    response.put("created", System.currentTimeMillis() / 1000);
+    response.put("model", "gpt-5-nano");
+    response.put(
+        "choices",
+        List.of(
+            Map.of(
+                "index",
+                0,
+                "message",
+                Map.of("role", "assistant", "content", contentJson),
+                "finish_reason",
+                "stop")));
+    response.put("usage", Map.of("prompt_tokens", 10, "completion_tokens", 20, "total_tokens", 30));
+    return response;
+  }
+
+  // ==================== Content 빌더 ====================
+
+  /**
+   * UserMessageAnalysisResult를 JSON 문자열로 변환합니다.
+   *
+   * <p>UserMessageAnalysisResult의 isXxx() 메서드들이 Jackson에 의해 필드로 직렬화되는 것을 방지하기 위해 필요한 필드만 Map으로
+   * 구성합니다.
+   */
+  private static String buildContentJson(UserMessageAnalysisResult result) {
+    Map<String, Object> contentMap = new HashMap<>();
+    contentMap.put("intent", result.getIntent());
+    contentMap.put("keywords", result.getKeywords() != null ? result.getKeywords() : List.of());
+
+    if (result.getSemanticTags() != null) {
+      contentMap.put("semantic_tags", result.getSemanticTags());
+    }
+    if (result.getReply() != null) {
+      contentMap.put("reply", result.getReply());
+    }
+
+    return toJson(contentMap);
+  }
+
+  // ==================== 유틸리티 ====================
+
+  private static String toJson(Object obj) {
+    try {
+      return OBJECT_MAPPER.writeValueAsString(obj);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("JSON 직렬화 실패", e);
+    }
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -43,5 +43,5 @@ discord:
 openai:
   api:
     key: test-api-key
-    model: gpt-4o-mini
+    model: gpt-5-nano
     base-url: https://api.openai.com


### PR DESCRIPTION
## Summary

- WireMock 기반 OpenAI API Mock 서버 구축
- Burst/Sustained 부하 테스트 구현
- `./gradlew loadTest` 명령으로 성능 테스트 실행 가능

## Changes

### 테스트 파일
- `AiChatServiceLoadTest`: Burst(100개 동시)/Sustained(5/초×10초) 성능 측정
- `OpenAiResponseFixture`: OpenAI Chat Completion API 응답 Mock 생성

### 설정 변경
- `OpenAiConfig`: baseUrl 설정 추가 (테스트 시 WireMock URL 주입)
- `build.gradle`: loadTest 태스크 추가, 기본 test에서 load-test 태그 제외
- `application-test.yml`: 테스트용 모델명 gpt-5-nano 통일

## Test Plan

- [x] `./gradlew test` - 기존 테스트 통과 확인
- [x] `./gradlew loadTest` - 부하 테스트 실행 확인
- [x] Burst 테스트: 100개 동시 요청 처리 확인
- [x] Sustained 테스트: 10초 지속 부하 처리 확인

## Related Issue

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive load testing suite for AI chat service with burst and sustained load scenarios
  * Added test fixtures for mock OpenAI API responses

* **Chores**
  * Added dedicated loadTest Gradle task for performance testing
  * Extended OpenAI client configuration to support customizable base URL
  * Updated test infrastructure and configuration to isolate load tests from standard test runs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->