### PR TITLE
🥅 fix(discord): AI 응답 누락 버그 수정 및 프로덕션 이슈 해결

### DIFF
--- a/src/main/java/com/vatti/chzscout/backend/discord/presentation/listener/MessageListener.java
+++ b/src/main/java/com/vatti/chzscout/backend/discord/presentation/listener/MessageListener.java
@@ -79,6 +79,8 @@ public class MessageListener extends ListenerAdapter {
   }
 
   private void handleAnalysisResult(MessageChannelUnion channel, UserMessageAnalysisResult result) {
+    log.info("AI 분석 결과 - intent: {}, reply: {}", result.getIntent(), result.getReply());
+
     if (result.isRecommendationRequest()) {
       // 의미 태그와 키워드를 합쳐서 검색
       List<String> allTags = combineTagsAndKeywords(result);
@@ -98,8 +100,12 @@ public class MessageListener extends ListenerAdapter {
         publishResponse(channel, recommendation);
       }
     } else if (result.hasDirectReply()) {
-      // search 또는 other: GPT가 생성한 reply를 그대로 전송
+      // search, greeting, other: GPT가 생성한 reply를 그대로 전송
       publishResponse(channel, result.getReply());
+    } else {
+      // Fallback: AI가 reply를 생성하지 않은 경우
+      log.warn("AI가 reply를 생성하지 않음 - intent: {}", result.getIntent());
+      publishResponse(channel, "죄송해요, 요청을 이해하지 못했어요. '롤 방송 추천해줘'처럼 원하시는 방송 스타일을 말씀해주세요! 🎮");
     }
   }
 


### PR DESCRIPTION
## Summary
- AI가 reply를 생성하지 않았을 때 응답이 누락되는 버그 수정
- 프로덕션 환경에서 발생한 인증/보안 이슈 해결

## Changes

### 🥅 Bug Fix - Discord 봇 응답 누락
- `MessageListener.handleAnalysisResult()`에 fallback else 분기 추가
- AI가 reply를 null로 반환할 때도 사용자에게 응답 전송
- 디버깅을 위한 AI 분석 결과 로깅 추가

### 🔒 Security & Auth
- `SecurityConfig`: 인증 실패 시 401 JSON 응답 반환
- `MemberController`: userDetails null 체크 추가

### 🤖 AI Prompt Improvement
- Intent 분류 프롬프트 개선 (한국어 표현 "찾아줘" 등 인식 강화)
- 우선순위 기반 판단 흐름 적용
- Fallback 전략: 애매한 경우 recommendation 선택

### 🐛 Other Fixes
- `Collectors.toMap` 중복 키 예외 처리

## Test Plan
- [ ] Discord 봇에 "명조 방송 찾아줘" 전송 → 응답 확인
- [ ] 인증 없이 `/v1/members/me` 접근 → 401 JSON 응답 확인
- [ ] EC2 로그에서 intent/reply 로깅 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message handling to ensure users receive a fallback response when AI analysis doesn't generate a reply, providing better user experience and preventing silent failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->