### PR TITLE
👷 ci(cd): Docker 정리를 pull 전후로 강화

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,14 +81,17 @@ jobs:
             export DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
             export IMAGE_TAG=${{ github.sha }}
 
+            # [Pull 전] 디스크 공간 확보 (미사용 이미지, 컨테이너, 볼륨 정리)
+            docker system prune -af --volumes || true
+
             # 새 이미지 가져오기
             docker compose -f docker-compose.yml -f docker-compose.prod.yml pull app
 
             # 컨테이너 강제 재생성 (새 이미지 적용 보장)
             docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --force-recreate --no-deps app
 
-            # 사용하지 않는 이미지 정리 (디스크 공간 확보)
-            docker image prune -f
+            # [Pull 후] 교체된 이전 이미지 정리
+            docker image prune -af
 
             # 배포된 이미지 버전 확인
             echo "=== Deployed Image ==="


### PR DESCRIPTION
## Summary
- EC2 배포 시 디스크 공간 부족 문제 해결
- Docker 정리를 pull 전후로 실행하여 안정적인 배포 보장

## Changes

### Pull 전 정리 추가
```bash
docker system prune -af --volumes || true
```
- 미사용 이미지, 컨테이너, 볼륨 모두 정리
- 새 이미지 다운로드 공간 확보
- `|| true`로 실패해도 스크립트 계속 진행

### Pull 후 정리 강화
```bash
docker image prune -af  # 기존: -f
```
- `-a` 플래그 추가로 모든 미사용 이미지 삭제

## Test Plan
- [ ] CD 파이프라인 실행 시 디스크 정리 로그 확인
- [ ] 배포 성공 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced deployment process with improved disk space management during image pulls.
  * Strengthened cleanup procedures to remove all unused container images after deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->