### PR TITLE
🚑️ fix(cors): CORS preflight 요청 허용으로 로그인 에러 수정

### DIFF
--- a/src/main/java/com/vatti/chzscout/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/vatti/chzscout/backend/common/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -49,6 +50,9 @@ public class SecurityConfig {
         .authorizeHttpRequests(
             auth ->
                 auth
+                    // CORS preflight 요청 허용
+                    .requestMatchers(HttpMethod.OPTIONS, "/**")
+                    .permitAll()
                     // Swagger UI
                     .requestMatchers(
                         "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/v3/api-docs")


### PR DESCRIPTION
## Summary
- 프론트엔드 로그인 시 CORS 에러로 인한 로그인 실패 수정
- OPTIONS preflight 요청에 대한 명시적 permitAll() 추가

## Problem
- `authenticationEntryPoint` 추가 후 OPTIONS 요청이 401로 처리됨
- CORS 헤더 없이 401 응답 → 브라우저가 CORS 에러로 판단
- 프론트엔드에서 "Login failed" 에러 발생

## Solution
```java
.requestMatchers(HttpMethod.OPTIONS, "/**")
.permitAll()
```

## Test Plan
- [ ] 프론트엔드에서 Discord 로그인 테스트
- [ ] 브라우저 콘솔에서 CORS 에러 없음 확인
- [ ] EC2 로그에서 `/v1/auth/discord/callback` 요청 도달 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CORS preflight request handling to ensure cross-origin requests are properly processed before other security authorization rules are applied.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->